### PR TITLE
fix bullet issue with Logseq 0.0.1 canary

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -759,11 +759,11 @@ HIGHLIGHT CURRENT PATH
 - option: (:hover) to (:focus-within)
 ==================================================
 */
-.ls-block .bullet {
+.ls-block .bullet-container .bullet {
   background-color: var(--pink);
 }
 
-.ls-block:not(:hover) .bullet {
+.ls-block:not(:hover) .bullet-container .bullet {
   background-color: var(--ls-block-bullet-color);
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31028998/117430802-0e326300-af5b-11eb-8fd7-a9d454b83a93.png)

I found Logseq new version has bullet issue and try fix it.

I'm not run production build beacuse I don't use Sass in production. 

Plz merge it and buld production css file.